### PR TITLE
add a button and confirmation to delete the private key

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,10 @@
                     <p class="lead mb-4" style="font-size: 16px; color: #777;">Below is the decrypted secret shared with you.</p>
                     <textarea class="form-control" id="dataForDecryption" rows="5"
                               v-model="inputData" disabled style="border-radius: 5px;"></textarea>
+                    <p id="deleteKeyLabel" class="mt-3">Done with this secret?</p>
+                    <button id="requestDeleteBtn" class="btn btn-danger" @click="promptConfirmDeleteKey">Delete the private key</button>
+                    <button id="cancelDeleteBtn" class="btn btn-warning d-none mx-1" @click="cancelDeleteKey">Nevermind, keep it</button>
+                    <button id="confirmDeleteBtn" class="btn btn-danger d-none mx-1" @click="deleteKey">I am sure, delete it</button>
                 </div>
                 <div v-else>
                     <p class="lead mb-4">Somebody is requesting a secret</br>

--- a/js/app.js
+++ b/js/app.js
@@ -59,6 +59,27 @@ createApp({
             })
         }
 
+        function promptConfirmDeleteKey() {
+            $("#deleteKeyLabel").text("Deletion is permanent. You will no longer be able to decrypt or see the secret. Are you sure?")
+            $("#confirmDeleteBtn").removeClass("d-none");
+            $("#cancelDeleteBtn").removeClass("d-none");
+            $("#requestDeleteBtn").addClass("d-none");
+        }
+
+        function cancelDeleteKey() {
+            $("#deleteKeyLabel").text("Done with this secret?")
+            $("#confirmDeleteBtn").addClass("d-none");
+            $("#cancelDeleteBtn").addClass("d-none");
+            $("#requestDeleteBtn").removeClass("d-none");
+        }
+
+        function deleteKey() {
+            let publicKey = localStorage.getItem("publicKey")
+            localStorage.removeItem(publicKey)
+            localStorage.removeItem("publicKey")
+            window.location = window.location.origin + window.location.pathname
+        }
+
         function decrypt() {
             let [pubKeySer, encryptedText] = location.hash.replace('#', '').split(';')
             load_key(window.localStorage.getItem(pubKeySer), 'decrypt').then(function (privKey) {
@@ -106,6 +127,9 @@ createApp({
 
         return {
             encrypt,
+            promptConfirmDeleteKey,
+            cancelDeleteKey,
+            deleteKey,
             encryptedUrl,
             inputData,
             newSecret,


### PR DESCRIPTION
Very neat project and idea, thanks for publishing it!

I noticed that there wasn't an easy way to "cleanup" after the user is done with the secret. I tinkered for a little bit and added a delete key button and confirmation afterward to hopefully avoid accidental deletion. 

![image](https://github.com/Corgea/retriever/assets/2406189/6e56f59a-199b-47f6-9a6d-186a2ef78c6d)

confirmation:
![image](https://github.com/Corgea/retriever/assets/2406189/591a02d7-3a32-41d8-8a57-8cbd5ab4209b)


If there is interest in having this feature, I am open to feedback regarding the code. Vue and JS more generally are not my forte, I tried to keep it simple but perhaps there are better ways.

I also understand if there isn't interest in having the feature. We can close the PR if that is the case. Partially I was just interested in learning how it works and seeing if I could manage to add this functionality.